### PR TITLE
Update docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ ACCOUNT_TOKEN=MyAccountToken
 REGION_CODE=us
 ```
 
+Create External network
+```
+$ docker network create dockercompose_testcluster
+```
+
 Start the demo:
 ```
 $ docker-compose up

--- a/README.md
+++ b/README.md
@@ -17,19 +17,19 @@ REGION_CODE=us
 
 Create External network
 ```
-$ docker network create dockercompose_testcluster
+docker network create dockercompose_testcluster
 ```
 
 Start the demo:
 ```
-$ docker-compose up
+docker-compose up
 ```
 
 Open http://127.0.0.1:18080 and click on the buttons to send traces.
 
 `Ctrl+C` to stop the demo and then remove the containers with:
 ```
-$ docker-compose down
+docker-compose down
 ```
 
 ## Additional References

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,8 +12,8 @@ services:
         networks:
             - dockercompose_testcluster
     jaeger-agent:
-        image: jaegertracing/jaeger-agent:1.18.0
-        command: ["--reporter.grpc.host-port=jaeger-logzio-collector:14250"]
+        image: jaegertracing/jaeger-agent:latest
+        command: ["--agent.tags=span_type=demo","--reporter.grpc.host-port=jaeger-logzio-collector:14250"]
         ports:
             - 5775:5775/udp
             - 6831:6831/udp
@@ -22,7 +22,7 @@ services:
         networks:
             - dockercompose_testcluster
     hotrod:
-        image: jaegertracing/example-hotrod:1.9
+        image: jaegertracing/example-hotrod:latest
         environment:
             - JAEGER_AGENT_HOST=jaeger-agent
         ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
         networks:
             - dockercompose_testcluster
     jaeger-agent:
-        image: jaegertracing/jaeger-agent:latest
+        image: jaegertracing/jaeger-agent:1.28.0
         command: ["--agent.tags=span_type=demo","--reporter.grpc.host-port=jaeger-logzio-collector:14250"]
         ports:
             - 5775:5775/udp
@@ -22,7 +22,7 @@ services:
         networks:
             - dockercompose_testcluster
     hotrod:
-        image: jaegertracing/example-hotrod:latest
+        image: jaegertracing/example-hotrod:1.28.0
         environment:
             - JAEGER_AGENT_HOST=jaeger-agent
         ports:


### PR DESCRIPTION
- Update to the latest images release
- Add tag "span_type=demo" so customers can separate between demo spans and regular spans